### PR TITLE
support --compressed option

### DIFF
--- a/src/main/java/org/toilelibre/libe/curl/Arguments.java
+++ b/src/main/java/org/toilelibre/libe/curl/Arguments.java
@@ -19,6 +19,8 @@ final class Arguments {
 
     final static Option  CERT_TYPE        = Arguments.add (Option.builder ("ct").longOpt ("cert-type").desc ("certificate type").required (false).hasArg (true).desc ("PEM|P12|JKS|DER|ENG").build ());
 
+    final static Option  COMPRESSED       = Arguments.add (Option.builder (null).longOpt ("compressed").desc ("Request compressed response (using deflate or gzip)").required (false).hasArg (false).build ());
+
     final static Option  CONNECT_TIMEOUT  = Arguments.add (Option.builder ("cti").longOpt ("connect-timeout").desc ("Maximum time allowed for connection").required (false).hasArg (true).argName("seconds").build ());
 
     final static Option  DATA             = Arguments.add (Option.builder ("d").longOpt ("data").desc ("Data").required (false).hasArg ().argName ("payload").build ());


### PR DESCRIPTION
In the curl doc.

```
     --compressed    Request compressed response (using deflate or gzip)
```

HttpClient has added this header by default
```
Accept-Encoding: gzip, deflate
```
so I have not changed any implementations. just to handle the error of missing options.
```
 org.apache.commons.cli.UnrecognizedOptionException: Unrecognized option: --compressed
```

