### PR TITLE
Bump tomcat-embed-core from 9.0.41 to 9.0.43

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
 		<dependency>
 			<groupId>org.apache.tomcat.embed</groupId>
 			<artifactId>tomcat-embed-core</artifactId>
-			<version>9.0.41</version>
+			<version>9.0.43</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Bumps tomcat-embed-core from 9.0.41 to 9.0.43.

---
updated-dependencies:
- dependency-name: org.apache.tomcat.embed:tomcat-embed-core
  dependency-type: direct:development
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>