### PR TITLE
Custom HttpClientBuilder（自定义HttpClientBuilder扩展）

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ curl()
        HttpResponse response = responseSupplier.get();
        LOGGER.info("I log something after the call, status code is {}",
        response.getStatusLine().getStatusCode());
-       return response;}))
-                      .connectionManager(new PoolingHttpClientConnectionManager ())
-                      .placeHolders(asList("fr-FR", "text/html")).build())
+       return response;})).httpClientBuilder(HttpClients.custom()
+                      .setConnectionManager(new PoolingHttpClientConnectionManager ())
+                      .placeHolders(asList("fr-FR", "text/html"))).build())
    .hUpperCase("'Accept-Language: $curl_placeholder_0'")
    .hUpperCase("'Accept: $curl_placeholder_1'")
    .run("http://www.google.com");

--- a/src/main/java/org/toilelibre/libe/curl/Curl.java
+++ b/src/main/java/org/toilelibre/libe/curl/Curl.java
@@ -3,6 +3,7 @@ package org.toilelibre.libe.curl;
 import org.apache.commons.cli.*;
 import org.apache.http.*;
 import org.apache.http.conn.*;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 import java.io.*;
 import java.util.*;
@@ -69,7 +70,7 @@ public final class Curl {
             stopAndDisplayVersionIfThe (commandLine.hasOption (Arguments.VERSION.getOpt ()));
             final HttpResponse response =
                     HttpClientProvider.prepareHttpClient (commandLine, curlJavaOptions.getInterceptors (),
-                            curlJavaOptions.getConnectionManager ()).execute (
+                            curlJavaOptions.getHttpClientBuilder()).execute (
                             HttpRequestProvider.prepareRequest (commandLine));
             AfterResponse.handle (commandLine, response);
             return response;
@@ -94,12 +95,12 @@ public final class Curl {
         public static class CurlJavaOptions {
             private final List<BiFunction<HttpRequest, Supplier<HttpResponse>, HttpResponse>> interceptors;
             private final List<String> placeHolders;
-            private final HttpClientConnectionManager connectionManager;
+            private final HttpClientBuilder httpClientBuilder;
 
             private CurlJavaOptions (Builder builder) {
                 interceptors = builder.interceptors;
                 placeHolders = builder.placeHolders;
-                connectionManager = builder.connectionManager;
+                httpClientBuilder = builder.httpClientBuilder;
             }
 
             public static Builder with () {
@@ -114,15 +115,15 @@ public final class Curl {
                 return placeHolders;
             }
 
-            public HttpClientConnectionManager getConnectionManager () {
-                return connectionManager;
+            public HttpClientBuilder getHttpClientBuilder () {
+                return this.httpClientBuilder;
             }
 
             public static final class Builder {
                 private List<BiFunction<HttpRequest, Supplier<HttpResponse>, HttpResponse>> interceptors
                         = new ArrayList<> ();
                 private List<String> placeHolders;
-                private HttpClientConnectionManager connectionManager;
+                private HttpClientBuilder httpClientBuilder;
 
                 private Builder () {
                 }
@@ -137,8 +138,8 @@ public final class Curl {
                     return this;
                 }
 
-                public Builder connectionManager (HttpClientConnectionManager val) {
-                    connectionManager = val;
+                public Builder httpClientBuilder (HttpClientBuilder httpClientBuilder) {
+                    this.httpClientBuilder = httpClientBuilder;
                     return this;
                 }
 

--- a/src/main/java/org/toilelibre/libe/curl/HttpClientProvider.java
+++ b/src/main/java/org/toilelibre/libe/curl/HttpClientProvider.java
@@ -18,32 +18,29 @@ final class HttpClientProvider {
 
     static HttpClient prepareHttpClient (final CommandLine commandLine,
                                          List<BiFunction<HttpRequest, Supplier<HttpResponse>, HttpResponse>> additionalInterceptors,
-                                         HttpClientConnectionManager connectionManager) throws CurlException {
-        HttpClientBuilder executor = HttpClientBuilder.create ();
+                                         HttpClientBuilder httpClientBuilder) throws CurlException {
+        if(httpClientBuilder == null)
+            httpClientBuilder = HttpClientBuilder.create ();
 
         if (!commandLine.hasOption (Arguments.COMPRESSED.getOpt ())){
-            executor.disableContentCompression ();
-        }
-
-        if (connectionManager != null) {
-            executor.setConnectionManager (connectionManager);
+            httpClientBuilder.disableContentCompression ();
         }
 
         final String hostname;
         try {
             hostname = InetAddress.getLocalHost ().getHostName ();
         } catch (final UnknownHostException e1) {
-            throw new Curl.CurlException (e1);
+            throw new CurlException (e1);
         }
 
-        executor = handleAuthMethod (commandLine, executor, hostname);
+        httpClientBuilder = handleAuthMethod (commandLine, httpClientBuilder, hostname);
 
         if (! commandLine.hasOption (Arguments.FOLLOW_REDIRECTS.getOpt ())) {
-            executor.disableRedirectHandling ();
+            httpClientBuilder.disableRedirectHandling ();
         }
 
-        handleSSLParams (commandLine, executor);
-        InterceptorsBinder.handleInterceptors (commandLine, executor, additionalInterceptors);
-        return executor.build ();
+        handleSSLParams (commandLine, httpClientBuilder);
+        InterceptorsBinder.handleInterceptors (commandLine, httpClientBuilder, additionalInterceptors);
+        return httpClientBuilder.build ();
     }
 }

--- a/src/main/java/org/toilelibre/libe/curl/HttpRequestProvider.java
+++ b/src/main/java/org/toilelibre/libe/curl/HttpRequestProvider.java
@@ -21,10 +21,13 @@ import static java.util.stream.Collectors.*;
 import static org.toilelibre.libe.curl.IOUtils.*;
 import static org.toilelibre.libe.curl.PayloadReader.*;
 
-final class HttpRequestProvider {
+public final class HttpRequestProvider {
 
-    static HttpUriRequest prepareRequest (final CommandLine commandLine) throws CurlException {
+    public static HttpUriRequest prepareRequest (final CommandLine commandLine) throws CurlException {
+        return requestBuilder(commandLine).build ();
+    }
 
+    public static RequestBuilder requestBuilder (final CommandLine commandLine) throws CurlException {
         final String method = getMethod (commandLine);
         final RequestBuilder request = wrapInRequestBuilder (method, commandLine.getArgs ()[0]);
 
@@ -40,7 +43,7 @@ final class HttpRequestProvider {
 
         request.setConfig (HttpRequestProvider.getConfig (commandLine));
 
-        return request.build ();
+        return request;
 
     }
 

--- a/src/test/java/org/toilelibre/libe/outside/curl/CurlFakeTest.java
+++ b/src/test/java/org/toilelibre/libe/outside/curl/CurlFakeTest.java
@@ -6,6 +6,7 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpRequestWrapper;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.VersionInfo;
@@ -98,12 +99,12 @@ public class CurlFakeTest {
 
     private HttpResponse curl (final String requestCommand, Consumer<HttpContext> assertions) {
         return org.toilelibre.libe.curl.Curl.curl (requestCommand,
-                Curl.CurlArgumentsBuilder.CurlJavaOptions.with ().connectionManager (
+                Curl.CurlArgumentsBuilder.CurlJavaOptions.with ().httpClientBuilder(HttpClients.custom().setConnectionManager(
                         new PoolingHttpClientConnectionManager (RegistryBuilder.<ConnectionSocketFactory>create ()
                                 .register ("https", new FakeConnectionSocketFactory (assertions))
                                 .register ("http", new FakeConnectionSocketFactory (assertions))
                                 .build (),
-                                host -> new InetAddress[] {InetAddress.getLoopbackAddress ()})).build ());
+                                host -> new InetAddress[] {InetAddress.getLoopbackAddress ()}))).build ());
     }
 
     private static class FakeConnectionSocketFactory implements ConnectionSocketFactory {

--- a/src/test/java/org/toilelibre/libe/outside/curl/CurlTest.java
+++ b/src/test/java/org/toilelibre/libe/outside/curl/CurlTest.java
@@ -8,6 +8,7 @@ import org.apache.http.config.*;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.conn.socket.*;
 import org.apache.http.conn.ssl.*;
+import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.*;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.assertj.core.api.Assertions;
@@ -171,12 +172,12 @@ public class CurlTest {
         KeyStore keystore = KeyStore.getInstance ("JKS");
         keystore.load (Thread.currentThread ().getContextClassLoader ().getResourceAsStream ("clients/libe/libe.jks"), "mylibepass".toCharArray ());
         this.assertOk (this.curl ("https://localhost:%d/public/",
-                with ().connectionManager (new PoolingHttpClientConnectionManager (RegistryBuilder.<ConnectionSocketFactory>create ()
+                with ().httpClientBuilder(HttpClients.custom().setConnectionManager (new PoolingHttpClientConnectionManager (RegistryBuilder.<ConnectionSocketFactory>create ()
                         .register ("https", new SSLConnectionSocketFactory (SSLContextBuilder.create ()
                                 .loadTrustMaterial (null, new TrustSelfSignedStrategy ())
                                 .loadKeyMaterial (keystore, "mylibepass".toCharArray ())
                                 .build (), NoopHostnameVerifier.INSTANCE))
-                        .build ())).build ()));
+                        .build ()))).build ()));
     }
 
     @Test


### PR DESCRIPTION
本次提交有两个修改点（优化）：

1、将 requestBuilder 独立为方法，因为 RequestBuilder 除了本项目默认配置的一些参数之外，还有其他很多参数可以配置，暴露该方法可以交给用户更多的配置空间。

2、问题：HttpClientBuilder 除了可以配置 HttpClientConnectionManager 之外，还有 setRetryHandler 等等很多其他配置，目前的代码只提供了 setHttpClientConnectionManager 配置，如果用户希望进行更多的配置处理则无法实现。
方案：修改后将 HttpClientBuilder 的构造交由用户可自定义提供，取消 HttpClientConnectionManager 的设置，用户有 HttpClientConnectionManager 等需求时通过自定义 HttpClientBuilder 来实现。如果用户未自定义 HttpClientBuilder 则使用默认 create。